### PR TITLE
fix: chain unregistration and unregistration cancelling

### DIFF
--- a/pantos/servicenode/blockchains/ethereum.py
+++ b/pantos/servicenode/blockchains/ethereum.py
@@ -214,7 +214,7 @@ class EthereumClient(BlockchainClient):
             request = BlockchainClient._TransactionSubmissionStartRequest(
                 ContractAbi.PANTOS_HUB,
                 _HUB_UNREGISTER_SERVICE_NODE_FUNCTION_SELECTOR,
-                (self.__address), _HUB_UNREGISTER_SERVICE_NODE_GAS, None,
+                (self.__address, ), _HUB_UNREGISTER_SERVICE_NODE_GAS, None,
                 nonce)
             internal_transaction_id = self._start_transaction_submission(
                 request, node_connections)
@@ -269,8 +269,8 @@ class EthereumClient(BlockchainClient):
             request = BlockchainClient._TransactionSubmissionStartRequest(
                 ContractAbi.PANTOS_HUB,
                 _HUB_CANCEL_SERVICE_NODE_UNREGISTRATION_FUNCTION_SELECTOR,
-                (self.__address), _HUB_CANCEL_SERVICE_NODE_UNREGISTRATION_GAS,
-                None, nonce)
+                (self.__address, ),
+                _HUB_CANCEL_SERVICE_NODE_UNREGISTRATION_GAS, None, nonce)
             internal_transaction_id = self._start_transaction_submission(
                 request, node_connections)
             extra_info |= {'internal_transaction_id': internal_transaction_id}

--- a/tests/blockchains/test_ethereum.py
+++ b/tests/blockchains/test_ethereum.py
@@ -610,7 +610,7 @@ def test_unregister_node_correct(mock_start_transaction_submission,
     mock_start_transaction_submission.assert_called_once()
     unregister_request = mock_start_transaction_submission.call_args.args[0]
     assert unregister_request.contract_abi is ContractAbi.PANTOS_HUB
-    assert unregister_request.function_args == (service_node_address)
+    assert unregister_request.function_args == (service_node_address, )
 
 
 @unittest.mock.patch.object(EthereumClient, '_start_transaction_submission',
@@ -933,7 +933,7 @@ def test_cancel_unregistration_correct(mock_start_transaction_submission,
     mock_start_transaction_submission.assert_called_once()
     cancel_request = mock_start_transaction_submission.call_args.args[0]
     assert cancel_request.contract_abi is ContractAbi.PANTOS_HUB
-    assert cancel_request.function_args == (service_node_address)
+    assert cancel_request.function_args == (service_node_address, )
 
 
 @unittest.mock.patch.object(EthereumClient, '_start_transaction_submission',


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [X] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Unregistering and cancelling the unregistration of a service node does not work properly

## Related Tickets & Documents

- Closes: https://github.com/pantos-io/servicenode/issues/16