### PR TITLE
fix: missing debian template start services

### DIFF
--- a/.github/workflows/sonar.yaml
+++ b/.github/workflows/sonar.yaml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   shared:
+    if: github.repository == 'pantos-io/servicenode'
     uses: pantos-io/ci-workflows/.github/workflows/sonar.yml@v1
     secrets: inherit
     

--- a/configurator/DEBIAN/templates
+++ b/configurator/DEBIAN/templates
@@ -18,6 +18,11 @@ Type: boolean
 Default: true
 Description: Local RabbitMQ detected, configure? This will create a new database and user for the service unless previously configured.
 
+Template: pantos/common/start_services
+Type: boolean
+Default: true
+Description: Start the services after install?
+
 Template: pantos/configurator/finish_note
 Type: note
 Description: |


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     Before submitting a Pull Request, please ensure you've done the following:
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [X] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
Adds back a missing template that caused errors while installing. This wasn't triggered on CI as we're forcefully setting the DB non-interactively.

## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->

- Related Issue #
- Closes #

## QA Instructions

_Please replace this line with instructions on how to test your changes._


## [optional] Are there any post deployment tasks we need to perform?