### PR TITLE
[PAN-2344] No transfer retries with incorrect destination token

### DIFF
--- a/pantos/servicenode/blockchains/base.py
+++ b/pantos/servicenode/blockchains/base.py
@@ -183,6 +183,61 @@ class BlockchainClient(BlockchainHandler, ErrorCreator[BlockchainClientError]):
         """
         pass  # pragma: no cover
 
+    @dataclasses.dataclass
+    class ExternalTokenRecordRequest:
+        """Request data for reading an external token record.
+
+        Attributes
+        ----------
+        token_address : BlockchainAddress
+            The address of the token on the blockchain the external
+            token record is read from.
+        external_blockchain : Blockchain
+            The blockchain to read the external token record for.
+
+        """
+        token_address: BlockchainAddress
+        external_blockchain: Blockchain
+
+    @dataclasses.dataclass
+    class ExternalTokenRecordResponse:
+        """Response data from reading an external token record.
+
+        Attributes
+        ----------
+        is_registration_active : bool
+            True if the external token registration is active.
+        external_token_address : BlockchainAddress
+            The registered external address of the token.
+
+        """
+        is_registration_active: bool
+        external_token_address: BlockchainAddress
+
+    @abc.abstractmethod
+    def read_external_token_record(
+            self, request: ExternalTokenRecordRequest) \
+            -> ExternalTokenRecordResponse:
+        """Read an external token record from the Pantos Hub.
+
+        Parameters
+        ----------
+        request : ExternalTokenRecordRequest
+            The request data.
+
+        Returns
+        -------
+        ExternalTokenRecordResponse
+            The response data.
+
+        Raises
+        ------
+        BlockchainClientError
+            If the external token record cannot be read.
+
+        """
+        pass  # pragma: no cover
+
     @abc.abstractmethod
     def read_minimum_deposit(self) -> int:
         """Read the service node's minimum deposit at the Pantos Hub on

--- a/pantos/servicenode/blockchains/ethereum.py
+++ b/pantos/servicenode/blockchains/ethereum.py
@@ -105,6 +105,29 @@ class EthereumClient(BlockchainClient):
         is_zero_address = int(recipient_address, 0) == 0
         return not is_zero_address
 
+    def read_external_token_record(
+            self, request: BlockchainClient.ExternalTokenRecordRequest) \
+            -> BlockchainClient.ExternalTokenRecordResponse:
+        # Docstring inherited
+        try:
+            node_connections = self.__create_node_connections()
+            hub_contract = self._create_hub_contract(node_connections)
+            external_token_record = hub_contract.caller().\
+                getExternalTokenRecord(request.token_address,
+                                       request.external_blockchain.value).get()
+            assert len(external_token_record) == 2
+            is_registration_active = external_token_record[0]
+            assert isinstance(is_registration_active, bool)
+            external_token_address = external_token_record[1]
+            assert isinstance(external_token_address, str)
+            return BlockchainClient.ExternalTokenRecordResponse(
+                is_registration_active=is_registration_active,
+                external_token_address=BlockchainAddress(
+                    external_token_address))
+        except Exception:
+            raise self._create_error('unable to read an external token record',
+                                     request=request)
+
     def read_minimum_deposit(self) -> int:
         # Docstring inherited
         try:

--- a/pantos/servicenode/blockchains/solana.py
+++ b/pantos/servicenode/blockchains/solana.py
@@ -47,6 +47,12 @@ class SolanaClient(BlockchainClient):
         # Docstring inherited
         raise NotImplementedError  # pragma: no cover
 
+    def read_external_token_record(
+            self, request: BlockchainClient.ExternalTokenRecordRequest) \
+            -> BlockchainClient.ExternalTokenRecordResponse:
+        # Docstring inherited
+        raise NotImplementedError  # pragma: no cover
+
     def read_minimum_deposit(self) -> int:
         # Docstring inherited
         raise NotImplementedError  # pragma: no cover


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

To avoid transfer retries when receiving a `PantosHub: incorrect external token` error message from the Pantos Hub, the external token record of the transfer's destination token is now validated before submitting a transfer transaction.